### PR TITLE
Fix Cannot assign null to property Laravel

### DIFF
--- a/src/Models/Components/LegacyRecurringProductPriceFixed.php
+++ b/src/Models/Components/LegacyRecurringProductPriceFixed.php
@@ -55,7 +55,7 @@ class LegacyRecurringProductPriceFixed
      */
     #[\Speakeasy\Serializer\Annotation\SerializedName('recurring_interval')]
     #[\Speakeasy\Serializer\Annotation\Type('\Polar\Models\Components\SubscriptionRecurringInterval')]
-    public SubscriptionRecurringInterval $recurringInterval;
+    public ?SubscriptionRecurringInterval $recurringInterval;
 
     /**
      * The currency.


### PR DESCRIPTION
Make recurring interval nullable since this is a fixed price product, not a subscription.

In Laravel Livewire, when I use the sdk to create a one time product with recurring interval set to null, I get this error

Cannot assign null to property Polar\Models\Components\LegacyRecurringProductPriceFixed::$recurringInterval of type Polar\Models\Components\SubscriptionRecurringInterval

because its not nullable. I have fixed it.